### PR TITLE
DBを使ったブログ一覧ページを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -7,3 +7,16 @@ export type Post = {
   content: string
   published: boolean
 }
+
+export const PostCard: React.FC<{ post: Post }> = ({ post }) => {
+  return (
+    <div className="border-gray-500 border-2 p-4 my-2">
+      <div className="text-xl">{post.title}</div>
+      <div className="flex flex-col">
+        <p className="text-sm">{post.author?.name}</p>
+        {/** TODO: 日付を出せると良さそう */}
+      </div>
+      <div className="truncate">{post.content}</div>
+    </div>
+  )
+}

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -1,0 +1,9 @@
+export type Post = {
+  id: string
+  title: string
+  author: {
+    name: string
+  } | null
+  content: string
+  published: boolean
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,16 @@ services:
     command: ['sh', '-c', 'yarn && yarn dev']
     ports:
       - 3000:3000
+    depends_on:
+      - db
+  db:
+    image: postgres:14.5-alpine
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+    volumes:
+      - db:/var/lib/postgresql/data
 
 volumes:
   node_modules:
+  db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       - POSTGRES_PASSWORD=password
     volumes:
       - db:/var/lib/postgresql/data
-
+    ports:
+      - 5432:5432
 volumes:
   node_modules:
   db:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-config-prettier": "^8.5.0",
     "postcss": "^8.4.16",
     "prettier": "^2.7.1",
+    "prisma": "^4.2.1",
     "tailwindcss": "^3.1.8",
     "twin.macro": "^2.8.2",
     "typescript": "4.7.4"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/react": "^11.10.0",
     "@emotion/server": "^11.10.0",
     "@emotion/styled": "^11.10.0",
+    "@prisma/client": "4.2.1",
     "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 import type { GetStaticProps } from 'next'
+import { Post, PostCard } from '../components/Post'
 
 export const getStaticProps: GetStaticProps = async () => {
   const prisma = new PrismaClient()
@@ -16,3 +17,18 @@ export const getStaticProps: GetStaticProps = async () => {
     revalidate: 10,
   }
 }
+
+const Blog: React.FC<{ posts: Post[] }> = ({ posts }) => {
+  return (
+    <main className="m-6">
+      <div className="text-2xl">ブログ一覧</div>
+      <div className="mt-6">
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
+    </main>
+  )
+}
+
+export default Blog

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,0 +1,18 @@
+import { PrismaClient } from '@prisma/client'
+import type { GetStaticProps } from 'next'
+
+export const getStaticProps: GetStaticProps = async () => {
+  const prisma = new PrismaClient()
+  const posts = await prisma.post.findMany({
+    where: { published: true },
+    include: {
+      author: {
+        select: { name: true },
+      },
+    },
+  })
+  return {
+    props: { posts },
+    revalidate: 10,
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,11 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,11 +1,28 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+// schema.prisma
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
 
 generator client {
   provider = "prisma-client-js"
 }
 
-datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+model Post {
+  id        String     @default(cuid()) @id
+  title     String
+  content   String?
+  published Boolean @default(false)
+  author    User?   @relation(fields: [authorId], references: [id])
+  authorId  String?
+}
+
+model User {
+  id            String       @default(cuid()) @id
+  name          String?
+  email         String?   @unique
+  createdAt     DateTime  @default(now()) @map(name: "created_at")
+  updatedAt     DateTime  @updatedAt @map(name: "updated_at")
+  posts         Post[]
+  @@map(name: "users")
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,6 +339,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@prisma/engines@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.2.1.tgz#60c7d0acc1c0c5b70ece712e2cbe13f46a345d6e"
+  integrity sha512-0KqBwREUOjBiHwITsQzw2DWfLHjntvbqzGRawj4sBMnIiL5CXwyDUKeHOwXzKMtNr1rEjxEsypM14g0CzLRK3g==
+
 "@rushstack/eslint-patch@^1.1.3":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz#0c8b74c50f29ee44f423f7416829c0bf8bb5eb27"
@@ -2182,6 +2187,13 @@ pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
+
+prisma@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.2.1.tgz#3558359f15021aa4767de8c6d0ca1f285cf33d65"
+  integrity sha512-HuYqnTDgH8atjPGtYmY0Ql9XrrJnfW7daG1PtAJRW0E6gJxc50lY3vrIDn0yjMR3TvRlypjTcspQX8DT+xD4Sg==
+  dependencies:
+    "@prisma/engines" "4.2.1"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,6 +339,18 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@prisma/client@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.2.1.tgz#b384587f6066070381ea4c90228a14697a0c271b"
+  integrity sha512-PZBkY60+k5oix+e6IUfl3ub8TbRLNsPLdfWrdy2eh80WcHTaT+/UfvXf/B7gXedH7FRtbPFHZXk1hZenJiJZFQ==
+  dependencies:
+    "@prisma/engines-version" "4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826"
+
+"@prisma/engines-version@4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826":
+  version "4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.2.0-33.2920a97877e12e055c1333079b8d19cee7f33826.tgz#63917e579b9f15460f102eaf08a4411a7e0666e7"
+  integrity sha512-tktkqdiwqE4QhmE088boPt+FwPj1Jub/zk+5F6sEfcRHzO5yz9jyMD5HFVtiwxZPLx/8Xg9ElnuTi8E5lWVQFQ==
+
 "@prisma/engines@4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.2.1.tgz#60c7d0acc1c0c5b70ece712e2cbe13f46a345d6e"


### PR DESCRIPTION
## 内容
- Docker を使って、ローカル環境に Postgres を立ち上げ
- Prisma を使って、Postgresに`Post` / `User`テーブルを作成
- PrismaClient を使って、Postgressから`Post`のデータを取得し、一覧ページを作成

<img width="1000" alt="スクリーンショット 2022-08-27 17 55 15" src="https://user-images.githubusercontent.com/49140783/187023233-c4fd675d-f0b3-4e0e-931f-3aaae076f831.png">


## 参考
https://vercel.com/guides/nextjs-prisma-postgres
https://github.com/prisma/blogr-nextjs-prisma

## メモ
ローカル環境用の`.env`は以下のようになっている
```
DATABASE_URL="postgresql://postgres:password@db:5432/local?schema=public"
```
これだと、docker外部からアクセスができないため、prismaでのdb schema push 時にエラーが出る
💭 `db`という通称でのアクセスは、dockerコンテナ同士にのみ許されている
```
-> % npx prisma db push
Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma
Datasource "db": PostgreSQL database "local", schema "public" at "db:5432"

Error: P1001: Can't reach database server at `db`:`5432`

Please make sure your database server is running at `db`:`5432`.
```
なので、prismaでのdb schema push 時もdockerを使うことにした
```
 docker compose run --rm app npx prisma db push
[+] Running 1/0
 ⠿ Container nextjs-customize-app_db_1  Running       0.0s
Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma
Datasource "db": PostgreSQL database "local", schema "public" at "db:5432"

The database is already in sync with the Prisma schema.

Running generate... (Use --skip-generate to skip the genera
✔ Generated Prisma Client (4.2.1 | library) to ./node_modules/@prisma/client in 
173ms
```